### PR TITLE
[model/gce]: Support local SSDs in GCP via label.

### DIFF
--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -17,6 +17,10 @@ limitations under the License.
 package gcemodel
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/pkg/model/defaults"
@@ -42,6 +46,10 @@ var _ fi.ModelBuilder = &AutoscalingGroupModelBuilder{}
 const (
 	preemptLabelKey   = "gcp.cloud.mux.io/preemptible-node"
 	minCPUPlatformKey = "gcp.cloud.mux.io/min-cpu-platform"
+	localSSDsKey      = "gcp.cloud.mux.io/local-ssds"
+
+	// DEPRECATED(dilyevsky): Support old label until migrated
+	preemptLabelKeyDeprecated = "cloud.mux.io/preemptible-node"
 )
 
 func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
@@ -101,8 +109,21 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			if _, ok := ig.Spec.NodeLabels[preemptLabelKey]; ok {
 				t.Preemptible = fi.Bool(true)
 			}
+			if _, ok := ig.Spec.NodeLabels[preemptLabelKeyDeprecated]; ok {
+				t.Preemptible = fi.Bool(true)
+			}
 			if v, ok := ig.Spec.NodeLabels[minCPUPlatformKey]; ok {
-				t.MinCPUPlatform = v
+				t.MinCPUPlatform = strings.ReplaceAll(v, "-", " ")
+			}
+			if v, ok := ig.Spec.NodeLabels[localSSDsKey]; ok {
+				i, err := strconv.Atoi(v)
+				if err != nil {
+					return fmt.Errorf("could not convert label %q to int: %v", v, err)
+				}
+
+				if i != 0 {
+					t.LocalSSDs = i32(int32(i))
+				}
 			}
 
 			switch ig.Spec.Role {

--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -39,7 +39,10 @@ type AutoscalingGroupModelBuilder struct {
 
 var _ fi.ModelBuilder = &AutoscalingGroupModelBuilder{}
 
-const preemptLabelKey = "cloud.mux.io/preemptible-node"
+const (
+	preemptLabelKey   = "gcp.cloud.mux.io/preemptible-node"
+	minCPUPlatformKey = "gcp.cloud.mux.io/min-cpu-platform"
+)
 
 func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	for _, ig := range b.InstanceGroups {
@@ -97,6 +100,9 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 
 			if _, ok := ig.Spec.NodeLabels[preemptLabelKey]; ok {
 				t.Preemptible = fi.Bool(true)
+			}
+			if v, ok := ig.Spec.NodeLabels[minCPUPlatformKey]; ok {
+				t.MinCPUPlatform = v
 			}
 
 			switch ig.Spec.Role {

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -60,8 +60,9 @@ type InstanceTemplate struct {
 
 	Scopes []string
 
-	Metadata    map[string]*fi.ResourceHolder
-	MachineType *string
+	Metadata       map[string]*fi.ResourceHolder
+	MachineType    *string
+	MinCPUPlatform string
 
 	// ID is the actual name
 	ID *string
@@ -106,6 +107,7 @@ func (e *InstanceTemplate) Find(c *fi.Context) (*InstanceTemplate, error) {
 			actual.Tags = append(actual.Tags, tag)
 		}
 		actual.MachineType = fi.String(lastComponent(p.MachineType))
+		actual.MinCPUPlatform = p.MinCpuPlatform
 		actual.CanIPForward = &p.CanIpForward
 
 		bootDiskImage, err := ShortenImageURL(cloud.Project(), p.Disks[0].InitializeParams.SourceImage)
@@ -284,7 +286,8 @@ func (e *InstanceTemplate) mapToGCE(project string) (*compute.InstanceTemplate, 
 
 			Disks: disks,
 
-			MachineType: *e.MachineType,
+			MachineType:    *e.MachineType,
+			MinCpuPlatform: e.MinCPUPlatform,
 
 			Metadata: &compute.Metadata{
 				Kind:  "compute#metadata",


### PR DESCRIPTION
* Parse out `gcp.cloud.mux.io/local-ssds` local SSD number and create this many local NVME drives on the instance.

* Also pick up support for min cpu platform via `gcp.cloud.mux.io/min-cpu-platform` label.